### PR TITLE
Return ErrNotFound, instead of separate bool return code

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -15,55 +15,49 @@ import (
 	jsonresp "github.com/sylabs/json-resp"
 )
 
-// getEntity returns the specified entity
-func (c *Client) getEntity(ctx context.Context, entityRef string) (*Entity, bool, error) {
+// getEntity returns the specified entity; returns ErrNotFound if entity is not
+// found, otherwise error
+func (c *Client) getEntity(ctx context.Context, entityRef string) (*Entity, error) {
 	url := "/v1/entities/" + entityRef
-	entJSON, found, err := c.apiGet(ctx, url)
+	entJSON, err := c.apiGet(ctx, url)
 	if err != nil {
-		return nil, false, err
-	}
-	if !found {
-		return nil, false, nil
+		return nil, err
 	}
 	var res EntityResponse
 	if err := json.Unmarshal(entJSON, &res); err != nil {
-		return nil, false, fmt.Errorf("error decoding entity: %v", err)
+		return nil, fmt.Errorf("error decoding entity: %v", err)
 	}
-	return &res.Data, found, nil
+	return &res.Data, nil
 }
 
-// getCollection returns the specified collection
-func (c *Client) getCollection(ctx context.Context, collectionRef string) (*Collection, bool, error) {
+// getCollection returns the specified collection; returns ErrNotFound if
+// collection is not found, otherwise error.
+func (c *Client) getCollection(ctx context.Context, collectionRef string) (*Collection, error) {
 	url := "/v1/collections/" + collectionRef
-	colJSON, found, err := c.apiGet(ctx, url)
+	colJSON, err := c.apiGet(ctx, url)
 	if err != nil {
-		return nil, false, err
-	}
-	if !found {
-		return nil, false, nil
+		return nil, err
 	}
 	var res CollectionResponse
 	if err := json.Unmarshal(colJSON, &res); err != nil {
-		return nil, false, fmt.Errorf("error decoding collection: %v", err)
+		return nil, fmt.Errorf("error decoding collection: %v", err)
 	}
-	return &res.Data, found, nil
+	return &res.Data, nil
 }
 
-// getContainer returns container by ref id
-func (c *Client) getContainer(ctx context.Context, containerRef string) (*Container, bool, error) {
+// getContainer returns container by ref id; returns ErrNotFound if container
+// is not found, otherwise error.
+func (c *Client) getContainer(ctx context.Context, containerRef string) (*Container, error) {
 	url := "/v1/containers/" + containerRef
-	conJSON, found, err := c.apiGet(ctx, url)
+	conJSON, err := c.apiGet(ctx, url)
 	if err != nil {
-		return nil, false, err
-	}
-	if !found {
-		return nil, false, nil
+		return nil, err
 	}
 	var res ContainerResponse
 	if err := json.Unmarshal(conJSON, &res); err != nil {
-		return nil, false, fmt.Errorf("error decoding container: %v", err)
+		return nil, fmt.Errorf("error decoding container: %v", err)
 	}
-	return &res.Data, found, nil
+	return &res.Data, nil
 }
 
 // createEntity creates an entity (must be authorized)
@@ -217,19 +211,17 @@ func (c *Client) setTag(ctx context.Context, containerID string, t ImageTag) err
 	return nil
 }
 
-// GetImage returns the Image object if exists, otherwise returns error
-func (c *Client) GetImage(ctx context.Context, imageRef string) (*Image, bool, error) {
+// GetImage returns the Image object if exists; returns ErrNotFound if image is
+// not found, otherwise error.
+func (c *Client) GetImage(ctx context.Context, imageRef string) (*Image, error) {
 	url := "/v1/images/" + imageRef
-	imgJSON, found, err := c.apiGet(ctx, url)
+	imgJSON, err := c.apiGet(ctx, url)
 	if err != nil {
-		return nil, false, err
-	}
-	if !found {
-		return nil, false, nil
+		return nil, err
 	}
 	var res ImageResponse
 	if err := json.Unmarshal(imgJSON, &res); err != nil {
-		return nil, false, fmt.Errorf("error decoding image: %v", err)
+		return nil, fmt.Errorf("error decoding image: %v", err)
 	}
-	return &res.Data, found, nil
+	return &res.Data, nil
 }

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -181,7 +181,7 @@ func Test_getEntity(t *testing.T) {
 			entityRef:    "notthere",
 			expectEntity: nil,
 			expectFound:  false,
-			expectError:  false,
+			expectError:  true,
 		},
 		{
 			description:  "Unauthorized",
@@ -225,7 +225,7 @@ func Test_getEntity(t *testing.T) {
 				t.Errorf("Error initializing client: %v", err)
 			}
 
-			entity, found, err := c.getEntity(context.Background(), tt.entityRef)
+			entity, err := c.getEntity(context.Background(), tt.entityRef)
 
 			if err != nil && !tt.expectError {
 				t.Errorf("Unexpected error: %v", err)
@@ -233,8 +233,8 @@ func Test_getEntity(t *testing.T) {
 			if err == nil && tt.expectError {
 				t.Errorf("Unexpected success. Expected error.")
 			}
-			if found != tt.expectFound {
-				t.Errorf("Got found %v - expected %v", found, tt.expectFound)
+			if err != nil && err == ErrNotFound && tt.expectFound {
+				t.Errorf("Got found %v - expected %v", err != ErrNotFound, tt.expectFound)
 			}
 			if !reflect.DeepEqual(entity, tt.expectEntity) {
 				t.Errorf("Got entity %v - expected %v", entity, tt.expectEntity)
@@ -263,7 +263,7 @@ func Test_getCollection(t *testing.T) {
 			collectionRef:    "notthere",
 			expectCollection: nil,
 			expectFound:      false,
-			expectError:      false,
+			expectError:      true,
 		},
 		{
 			description:      "Unauthorized",
@@ -307,7 +307,7 @@ func Test_getCollection(t *testing.T) {
 				t.Errorf("Error initializing client: %v", err)
 			}
 
-			collection, found, err := c.getCollection(context.Background(), tt.collectionRef)
+			collection, err := c.getCollection(context.Background(), tt.collectionRef)
 
 			if err != nil && !tt.expectError {
 				t.Errorf("Unexpected error: %v", err)
@@ -315,8 +315,8 @@ func Test_getCollection(t *testing.T) {
 			if err == nil && tt.expectError {
 				t.Errorf("Unexpected success. Expected error.")
 			}
-			if found != tt.expectFound {
-				t.Errorf("Got found %v - expected %v", found, tt.expectFound)
+			if err != nil && err == ErrNotFound && tt.expectFound {
+				t.Errorf("Got found %v - expected %v", err != ErrNotFound, tt.expectFound)
 			}
 			if !reflect.DeepEqual(collection, tt.expectCollection) {
 				t.Errorf("Got entity %v - expected %v", collection, tt.expectCollection)
@@ -345,7 +345,7 @@ func Test_getContainer(t *testing.T) {
 			containerRef:    "notthere",
 			expectContainer: nil,
 			expectFound:     false,
-			expectError:     false,
+			expectError:     true,
 		},
 		{
 			description:     "Unauthorized",
@@ -389,7 +389,7 @@ func Test_getContainer(t *testing.T) {
 				t.Errorf("Error initializing client: %v", err)
 			}
 
-			container, found, err := c.getContainer(context.Background(), tt.containerRef)
+			container, err := c.getContainer(context.Background(), tt.containerRef)
 
 			if err != nil && !tt.expectError {
 				t.Errorf("Unexpected error: %v", err)
@@ -397,8 +397,8 @@ func Test_getContainer(t *testing.T) {
 			if err == nil && tt.expectError {
 				t.Errorf("Unexpected success. Expected error.")
 			}
-			if found != tt.expectFound {
-				t.Errorf("Got found %v - expected %v", found, tt.expectFound)
+			if err != nil && err != ErrNotFound && tt.expectFound {
+				t.Errorf("Got found %v - expected %v", err != ErrNotFound, tt.expectFound)
 			}
 			if !reflect.DeepEqual(container, tt.expectContainer) {
 				t.Errorf("Got container %v - expected %v", container, tt.expectContainer)
@@ -427,7 +427,7 @@ func Test_getImage(t *testing.T) {
 			imageRef:    "notthere",
 			expectImage: nil,
 			expectFound: false,
-			expectError: false,
+			expectError: true,
 		},
 		{
 			description: "Unauthorized",
@@ -471,7 +471,7 @@ func Test_getImage(t *testing.T) {
 				t.Errorf("Error initializing client: %v", err)
 			}
 
-			image, found, err := c.GetImage(context.Background(), tt.imageRef)
+			image, err := c.GetImage(context.Background(), tt.imageRef)
 
 			if err != nil && !tt.expectError {
 				t.Errorf("Unexpected error: %v", err)
@@ -479,8 +479,8 @@ func Test_getImage(t *testing.T) {
 			if err == nil && tt.expectError {
 				t.Errorf("Unexpected success. Expected error.")
 			}
-			if found != tt.expectFound {
-				t.Errorf("Got found %v - expected %v", found, tt.expectFound)
+			if err != nil && err != ErrNotFound && tt.expectFound {
+				t.Errorf("Got found %v - expected %v", err != ErrNotFound, tt.expectFound)
 			}
 			if !reflect.DeepEqual(image, tt.expectImage) {
 				t.Errorf("Got image %v - expected %v", image, tt.expectImage)

--- a/client/push.go
+++ b/client/push.go
@@ -110,11 +110,11 @@ func (c *Client) UploadImage(ctx context.Context, r io.ReadSeeker, path string, 
 	c.Logger.Logf("Image hash computed as %s", imageHash)
 
 	// Find or create entity
-	entity, found, err := c.getEntity(ctx, entityName)
+	entity, err := c.getEntity(ctx, entityName)
 	if err != nil {
-		return err
-	}
-	if !found {
+		if err != ErrNotFound {
+			return err
+		}
 		c.Logger.Logf("Entity %s does not exist in library - creating it.", entityName)
 		entity, err = c.createEntity(ctx, entityName)
 		if err != nil {
@@ -124,11 +124,12 @@ func (c *Client) UploadImage(ctx context.Context, r io.ReadSeeker, path string, 
 
 	// Find or create collection
 	qualifiedCollectionName := fmt.Sprintf("%s/%s", entityName, collectionName)
-	collection, found, err := c.getCollection(ctx, qualifiedCollectionName)
+	collection, err := c.getCollection(ctx, qualifiedCollectionName)
 	if err != nil {
-		return err
-	}
-	if !found {
+		if err != ErrNotFound {
+			return err
+		}
+		// create collection
 		c.Logger.Logf("Collection %s does not exist in library - creating it.", collectionName)
 		collection, err = c.createCollection(ctx, collectionName, entity.ID)
 		if err != nil {
@@ -138,11 +139,12 @@ func (c *Client) UploadImage(ctx context.Context, r io.ReadSeeker, path string, 
 
 	// Find or create container
 	computedName := fmt.Sprintf("%s/%s", qualifiedCollectionName, containerName)
-	container, found, err := c.getContainer(ctx, computedName)
+	container, err := c.getContainer(ctx, computedName)
 	if err != nil {
-		return err
-	}
-	if !found {
+		if err != ErrNotFound {
+			return err
+		}
+		// Create container
 		c.Logger.Logf("Container %s does not exist in library - creating it.", containerName)
 		container, err = c.createContainer(ctx, containerName, collection.ID)
 		if err != nil {
@@ -151,11 +153,12 @@ func (c *Client) UploadImage(ctx context.Context, r io.ReadSeeker, path string, 
 	}
 
 	// Find or create image
-	image, found, err := c.GetImage(ctx, computedName+":"+imageHash)
+	image, err := c.GetImage(ctx, computedName+":"+imageHash)
 	if err != nil {
-		return err
-	}
-	if !found {
+		if err != ErrNotFound {
+			return err
+		}
+		// Create image
 		c.Logger.Logf("Image %s does not exist in library - creating it.", imageHash)
 		image, err = c.createImage(ctx, imageHash, container.ID, description)
 		if err != nil {

--- a/client/restclient.go
+++ b/client/restclient.go
@@ -20,39 +20,27 @@ import (
 )
 
 var (
+	// ErrNotFound is returned by when a resource is not found (http status 404)
 	ErrNotFound = errors.New("not found")
 )
 
-func (c *Client) apiGet(ctx context.Context, path string) (objJSON []byte, found bool, err error) {
+func (c *Client) apiGet(ctx context.Context, path string) (objJSON []byte, err error) {
 	c.Logger.Logf("apiGet calling %s", path)
 	return c.doGETRequest(ctx, path)
 }
 
 func (c *Client) apiCreate(ctx context.Context, url string, o interface{}) (objJSON []byte, err error) {
 	c.Logger.Logf("apiCreate calling %s", url)
-	objJSON, err = c.doPOSTRequest(ctx, url, o)
-	if err != nil {
-		return []byte{}, err
-	}
-	return
+	return c.doPOSTRequest(ctx, url, o)
 }
 
 func (c *Client) apiUpdate(ctx context.Context, url string, o interface{}) (objJSON []byte, err error) {
 	c.Logger.Logf("apiUpdate calling %s", url)
-
-	objJSON, err = c.doPUTRequest(ctx, url, o)
-	if err != nil {
-		return []byte{}, err
-	}
-	return
+	return c.doPUTRequest(ctx, url, o)
 }
 
-func (c *Client) doGETRequest(ctx context.Context, path string) (objJSON []byte, found bool, err error) {
-	objJSON, err = c.commonRequestHandler(ctx, "GET", path, nil, []int{http.StatusOK})
-	if err == ErrNotFound {
-		return []byte{}, false, nil
-	}
-	return objJSON, true, err
+func (c *Client) doGETRequest(ctx context.Context, path string) (objJSON []byte, err error) {
+	return c.commonRequestHandler(ctx, "GET", path, nil, []int{http.StatusOK})
 }
 
 func (c *Client) doPUTRequest(ctx context.Context, path string, o interface{}) (objJSON []byte, err error) {

--- a/client/search.go
+++ b/client/search.go
@@ -53,7 +53,7 @@ func (c *Client) Search(ctx context.Context, args map[string]string) (*SearchRes
 		v.Set(key, value)
 	}
 
-	resJSON, _, err := c.apiGet(ctx, "/v1/search?"+v.Encode())
+	resJSON, err := c.apiGet(ctx, "/v1/search?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Remove discrete `found` (`bool`) response from `getXXX()` APIs. Instead, return `ErrNotFound`