### PR TITLE
Revert "Send md5 metadata header (#54)"

### DIFF
--- a/client/push.go
+++ b/client/push.go
@@ -284,7 +284,6 @@ func (c *Client) postFileV2(ctx context.Context, r io.Reader, fileSize int64, im
 
 	req.ContentLength = fileSize
 	req.Header.Set("Content-Type", "application/octet-stream")
-	req.Header.Set("x-amz-meta-client-md5sum", metadata["md5sum"])
 
 	// redirect log output from retryablehttp to our logger
 	l := loggingAdapter{


### PR DESCRIPTION
This reverts commit 2de08beff4feed1367ef9c21ca39497cc0dc5e29.

With the roll-back of the cloud-library from using the AWS S3 client to
the Minio S3 lib, V2 uploads to an S3 backend fail with a
403. Minio uploads do succeed.

Local testing shows that reverting sending the md5 hash gives working
upload against a local library with both S3 and Minio backends.

If the server-side S3 lib is changed from Minio->AWS in future this may
need to be re-added.