### PR TITLE
Exported 'GetContainer' function

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -159,8 +159,8 @@ func (c *Client) setTags(ctx context.Context, containerID, imageID string, tags 
 	return nil
 }
 
-// GetTags returns a tag map for the specified containerID
-func (c *Client) GetTags(ctx context.Context, containerID string) (TagMap, error) {
+// getTags returns a tag map for the specified containerID
+func (c *Client) getTags(ctx context.Context, containerID string) (TagMap, error) {
 	url := fmt.Sprintf("/v1/tags/%s", containerID)
 	c.Logger.Logf("getTags calling %s", url)
 	req, err := c.newRequest(http.MethodGet, url, "", nil)

--- a/client/api.go
+++ b/client/api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -46,9 +46,9 @@ func (c *Client) getCollection(ctx context.Context, collectionRef string) (*Coll
 	return &res.Data, nil
 }
 
-// getContainer returns container by ref id; returns ErrNotFound if container
+// GetContainer returns container by ref id; returns ErrNotFound if container
 // is not found, otherwise error.
-func (c *Client) getContainer(ctx context.Context, containerRef string) (*Container, error) {
+func (c *Client) GetContainer(ctx context.Context, containerRef string) (*Container, error) {
 	url := "/v1/containers/" + containerRef
 	conJSON, err := c.apiGet(ctx, url)
 	if err != nil {
@@ -159,8 +159,8 @@ func (c *Client) setTags(ctx context.Context, containerID, imageID string, tags 
 	return nil
 }
 
-// getTags returns a tag map for the specified containerID
-func (c *Client) getTags(ctx context.Context, containerID string) (TagMap, error) {
+// GetTags returns a tag map for the specified containerID
+func (c *Client) GetTags(ctx context.Context, containerID string) (TagMap, error) {
 	url := fmt.Sprintf("/v1/tags/%s", containerID)
 	c.Logger.Logf("getTags calling %s", url)
 	req, err := c.newRequest(http.MethodGet, url, "", nil)

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -354,7 +354,7 @@ func Test_getCollection(t *testing.T) {
 	}
 }
 
-func Test_getContainer(t *testing.T) {
+func Test_GetContainer(t *testing.T) {
 
 	tests := []struct {
 		description     string
@@ -418,7 +418,7 @@ func Test_getContainer(t *testing.T) {
 				t.Errorf("Error initializing client: %v", err)
 			}
 
-			container, err := c.getContainer(context.Background(), tt.containerRef)
+			container, err := c.GetContainer(context.Background(), tt.containerRef)
 
 			if err != nil && !tt.expectError {
 				t.Errorf("Unexpected error: %v", err)

--- a/client/push.go
+++ b/client/push.go
@@ -137,7 +137,7 @@ func (c *Client) UploadImage(ctx context.Context, r io.ReadSeeker, path, arch st
 
 	// Find or create container
 	computedName := fmt.Sprintf("%s/%s", qualifiedCollectionName, containerName)
-	container, err := c.getContainer(ctx, computedName)
+	container, err := c.GetContainer(ctx, computedName)
 	if err != nil {
 		if err != ErrNotFound {
 			return err


### PR DESCRIPTION
This PR exports the `getContainer` function to be used in https://github.com/sylabs/singularity/pull/4818.