### PR TITLE
Update golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       - image: golang:1.14
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.29-alpine
+      - image: golangci/golangci-lint:v1.30-alpine
 
 jobs:
   lint_markdown:


### PR DESCRIPTION
Update `golangci-lint` to v1.30.