### PR TITLE
Do not urlencode the '=' in DeleteImage query string.

### DIFF
--- a/client/delete.go
+++ b/client/delete.go
@@ -12,6 +12,6 @@ func (c *Client) DeleteImage(ctx context.Context, imageRef, arch string) error {
 		return errors.New("imageRef and arch are required")
 	}
 
-	_, err := c.doDeleteRequest(ctx, "v1/images/"+imageRef+"?"+url.QueryEscape("arch="+arch))
+	_, err := c.doDeleteRequest(ctx, "v1/images/"+imageRef+"?arch="+url.QueryEscape(arch))
 	return err
 }

--- a/client/delete_test.go
+++ b/client/delete_test.go
@@ -3,51 +3,70 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 )
 
 func Test_DeleteImage(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
+		name        string
 		imageRef    string
 		arch        string
 		expectError bool
 		code        int
+		callback    func(*http.Request, *testing.T)
 	}{
 		{
-			imageRef:    "",
-			arch:        "",
+			name:        "MissingImageRefAndArch",
 			expectError: true,
 		},
 		{
+			name:        "MissingImageRef",
+			arch:        archIntel,
+			expectError: true,
+		},
+		{
+			name:        "MissingArch",
 			imageRef:    "test:v0.0.1",
-			arch:        "",
 			expectError: true,
 		},
 		{
+			name:     "ValidateQueryStringArch",
 			imageRef: "test",
-			arch:     "1",
-			code:     200,
+			arch:     archIntel,
+			code:     http.StatusOK,
+			callback: func(r *http.Request, t *testing.T) {
+				// ensure arch specified in query string is as expected
+				queryArch := r.URL.Query().Get("arch")
+				if queryArch != archIntel {
+					t.Errorf("got arch %v, want %v", queryArch, archIntel)
+				}
+			},
 		},
 	}
 
 	for _, tt := range tests {
-		m := mockService{
-			t:        t,
-			code:     tt.code,
-			httpPath: fmt.Sprintf("/v1/images/%s", tt.imageRef),
-		}
-		m.Run()
-		defer m.Stop()
-		c, err := NewClient(&Config{BaseURL: m.baseURI})
-		if err != nil {
-			t.Errorf("Error initializing client: %v", err)
-		}
+		tt := tt
 
-		err = c.DeleteImage(ctx, tt.imageRef, tt.arch)
-		if !tt.expectError && err != nil {
-			t.Errorf("Unexpected err: %s", err)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			m := mockService{
+				t:           t,
+				code:        tt.code,
+				httpPath:    fmt.Sprintf("/v1/images/%s", tt.imageRef),
+				reqCallback: tt.callback,
+			}
+			m.Run()
+			defer m.Stop()
+
+			c, err := NewClient(&Config{BaseURL: m.baseURI})
+			if err != nil {
+				t.Errorf("Error initializing client: %v", err)
+			}
+
+			err = c.DeleteImage(context.Background(), tt.imageRef, tt.arch)
+			if !tt.expectError && err != nil {
+				t.Errorf("Unexpected err: %s", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #104

Library was not recognising the `arch=<value>` parameter as the `=` was being urlencoded:

``
DELETE /v1/images/test/test/test:power?arch%3Damd64
``