### PR TITLE
CI Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@1.1
+  codecov: codecov/codecov@1.2
 
 executors:
   node:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
       - image: golangci/golangci-lint:v1.40-alpine
 
 jobs:
-  lint_markdown:
+  lint-markdown:
     executor: node
     steps:
       - checkout
@@ -26,7 +26,7 @@ jobs:
           name: Check for Lint
           command: markdownlint .
 
-  check_mod_tidy:
+  check-mod-tidy:
     executor: golang
     steps:
       - checkout
@@ -37,7 +37,7 @@ jobs:
           name: Check Module Tidiness
           command: git diff --exit-code -- go.mod go.sum
 
-  build_source:
+  build-source:
     executor: golang
     steps:
       - checkout
@@ -45,7 +45,7 @@ jobs:
           name: Build Source
           command: go build ./...
 
-  lint_source:
+  lint-source:
     executor: golangci-lint
     steps:
       - checkout
@@ -53,7 +53,7 @@ jobs:
           name: Check for Lint
           command: golangci-lint run
 
-  unit_test:
+  unit-test:
     executor: golang
     steps:
       - checkout
@@ -68,8 +68,8 @@ workflows:
 
   build_and_test:
     jobs:
-      - lint_markdown
-      - check_mod_tidy
-      - build_source
-      - lint_source
-      - unit_test
+      - lint-markdown
+      - check-mod-tidy
+      - build-source
+      - lint-source
+      - unit-test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
     - goprintffuncname
     - gosimple
     - govet
@@ -20,6 +19,7 @@ linters:
     - misspell
     - nakedret
     - prealloc
+    - revive
     - rowserrcheck
     - staticcheck
     - structcheck

--- a/client/version.go
+++ b/client/version.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	// API version that supports extended image uploadfunctionality
-	APIVersionV2Upload   = "2.0.0-alpha.1"
+	// APIVersionV2Upload supports extended image upload functionality.
+	APIVersionV2Upload = "2.0.0-alpha.1"
+	// APIVersionV2ArchTags supports extended arch tags functionality.
 	APIVersionV2ArchTags = "2.0.0-alpha.2"
 )
 


### PR DESCRIPTION
Update Codecov Orb to latest version. Replace deprecated `golint` linter with `revive`. Address lint found by `revive` linter. Use consistent naming convention (hyphens) in CI config.