### PR TITLE
Bump Go to 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ executors:
       - image: golangci/golangci-lint:v1.41-alpine
   golang-previous:
     docker:
-      - image: golang:1.15
+      - image: golang:1.16
   golang-latest:
     docker:
-      - image: golang:1.16
+      - image: golang:1.17
 
 jobs:
   lint-markdown:

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6,7 +6,7 @@
 package client
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -144,7 +144,7 @@ func TestNewRequest(t *testing.T) {
 					t.Errorf("got URL %v, want %v", got, want)
 				}
 
-				b, err := ioutil.ReadAll(r.Body)
+				b, err := io.ReadAll(r.Body)
 				if err != nil {
 					t.Errorf("failed to read body: %v", err)
 				}

--- a/client/pull_test.go
+++ b/client/pull_test.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -59,7 +58,7 @@ func (m *mockRawService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func Test_DownloadImage(t *testing.T) {
-	f, err := ioutil.TempFile("", "test")
+	f, err := os.CreateTemp("", "test")
 	if err != nil {
 		t.Fatalf("Error creating a temporary file for testing")
 	}
@@ -119,11 +118,11 @@ func Test_DownloadImage(t *testing.T) {
 			}
 
 			if tt.checkContent {
-				fileContent, err := ioutil.ReadFile(tt.outFile)
+				fileContent, err := os.ReadFile(tt.outFile)
 				if err != nil {
 					t.Errorf("Error reading test output file: %v", err)
 				}
-				testContent, err := ioutil.ReadFile(tt.testFile)
+				testContent, err := os.ReadFile(tt.testFile)
 				if err != nil {
 					t.Errorf("Error reading test file: %v", err)
 				}

--- a/client/restclient.go
+++ b/client/restclient.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -93,7 +92,7 @@ func (c *Client) commonRequestHandler(ctx context.Context, method string, path s
 		}
 		return []byte{}, fmt.Errorf("request did not succeed: http status code: %d", res.StatusCode)
 	}
-	objJSON, err = ioutil.ReadAll(res.Body)
+	objJSON, err = io.ReadAll(res.Body)
 	if err != nil {
 		return []byte{}, fmt.Errorf("error reading response from server:\n\t%v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/scs-library-client
 
-go 1.15
+go 1.17
 
 require (
 	github.com/blang/semver/v4 v4.0.0
@@ -8,4 +8,10 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/sylabs/json-resp v0.7.1
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )


### PR DESCRIPTION
Bump `go.mod` language version to 1.17 to take advantage of [lazy loading](https://golang.org/ref/mod#lazy-loading). Bump CI Go version range to 1.16-1.17. Remove use of deprecated `ioutil` package.