### PR TITLE
fix: follow relative Location in ConcurrentDownloadImage

### DIFF
--- a/client/pull.go
+++ b/client/pull.go
@@ -282,6 +282,10 @@ func (c *Client) ConcurrentDownloadImage(ctx context.Context, dst *os.File, arch
 	}
 
 	url := res.Header.Get("Location")
+	// If URL is not absolute, add it to our client BaseURL
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		url = c.BaseURL.String() + url
+	}
 
 	contentLength, err := getContentLength(ctx, url)
 	if err != nil {


### PR DESCRIPTION
ConcurrentDownloadImage traps redirects, and handles the Location header manually.If the Location is not an absolute URI we should append it to the client BaseURL.

We cannot use URL.ResolveRefence as...

- We have historically tried to accommodate services on subpaths... e.g. `https://service.example.com/cloud-library` as `BaseURL`.

- Location of `/v1/filepart/....` would then resolve to `https://cloud.example.com/v1/filepart/...` missing the `library` path part.

Fixes #127