### PR TITLE
CI Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: node:16-slim
+      - image: node:17-slim
   golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.43-alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:17-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.43-alpine
+      - image: golangci/golangci-lint:v1.44-alpine
   golang-previous:
     docker:
       - image: golang:1.16

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,11 +3,14 @@ linters:
   enable:
     - bidichk
     - bodyclose
+    - containedctx
     - contextcheck
     - deadcode
+    - decorder
     - depguard
     - dogsled
     - errcheck
+    - errchkjson
     - gochecknoinits
     - goconst
     - gocritic
@@ -17,8 +20,10 @@ linters:
     - goprintffuncname
     - gosimple
     - govet
+    - grouper
     - ineffassign
     - ireturn
+    - maintidx
     - misspell
     - nakedret
     - prealloc

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,7 @@
 # LICENSE
 
+Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.

--- a/client/util.go
+++ b/client/util.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -127,8 +127,9 @@ func StringInSlice(a string, list []string) bool {
 
 // PrettyPrint - Debug helper, print nice json for any interface
 func PrettyPrint(v interface{}) {
-	b, _ := json.MarshalIndent(v, "", "  ")
-	println(string(b))
+	if b, err := json.MarshalIndent(v, "", "  "); err == nil {
+		println(string(b))
+	}
 }
 
 // ImageHash returns the appropriate hash for a provided image file


### PR DESCRIPTION
Bump `node` to v17, and `golangci-lint` to v1.44.