### PR TITLE
(Re)use Client.HTTPClient for range requests

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -160,11 +160,11 @@ func (c *Client) setTags(ctx context.Context, containerID, imageID string, tags 
 func (c *Client) getTags(ctx context.Context, containerID string) (TagMap, error) {
 	url := fmt.Sprintf("v1/tags/%s", containerID)
 	c.Logger.Logf("getTags calling %s", url)
-	req, err := c.newRequest(http.MethodGet, url, "", nil)
+	req, err := c.newRequest(ctx, http.MethodGet, url, "", nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request to server:\n\t%v", err)
 	}
-	res, err := c.HTTPClient.Do(req.WithContext(ctx))
+	res, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error making request to server:\n\t%v", err)
 	}
@@ -192,11 +192,11 @@ func (c *Client) setTag(ctx context.Context, containerID string, t ImageTag) err
 	if err != nil {
 		return fmt.Errorf("error encoding object to JSON:\n\t%v", err)
 	}
-	req, err := c.newRequest("POST", url, "", bytes.NewBuffer(s))
+	req, err := c.newRequest(ctx, http.MethodPost, url, "", bytes.NewBuffer(s))
 	if err != nil {
 		return fmt.Errorf("error creating POST request:\n\t%v", err)
 	}
-	res, err := c.HTTPClient.Do(req.WithContext(ctx))
+	res, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("error making request to server:\n\t%v", err)
 	}
@@ -243,11 +243,11 @@ func (c *Client) setTagsV2(ctx context.Context, containerID, arch string, imageI
 func (c *Client) getTagsV2(ctx context.Context, containerID string) (ArchTagMap, error) {
 	url := fmt.Sprintf("v2/tags/%s", containerID)
 	c.Logger.Logf("getTagsV2 calling %s", url)
-	req, err := c.newRequest(http.MethodGet, url, "", nil)
+	req, err := c.newRequest(ctx, http.MethodGet, url, "", nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request to server:\n\t%v", err)
 	}
-	res, err := c.HTTPClient.Do(req.WithContext(ctx))
+	res, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error making request to server:\n\t%v", err)
 	}
@@ -275,11 +275,11 @@ func (c *Client) setTagV2(ctx context.Context, containerID string, t ArchImageTa
 	if err != nil {
 		return fmt.Errorf("error encoding object to JSON:\n\t%v", err)
 	}
-	req, err := c.newRequest("POST", url, "", bytes.NewBuffer(s))
+	req, err := c.newRequest(ctx, http.MethodPost, url, "", bytes.NewBuffer(s))
 	if err != nil {
 		return fmt.Errorf("error creating POST request:\n\t%v", err)
 	}
-	res, err := c.HTTPClient.Do(req.WithContext(ctx))
+	res, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("error making request to server:\n\t%v", err)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -6,6 +6,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -97,14 +98,9 @@ func NewClient(cfg *Config) (*Client, error) {
 	return c, nil
 }
 
-// newRequest returns a new Request given a method, path (relative or
-// absolute), rawQuery, and (optional) body.
-func (c *Client) newRequest(method, path, rawQuery string, body io.Reader) (*http.Request, error) {
-	u := c.BaseURL.ResolveReference(&url.URL{
-		Path:     path,
-		RawQuery: rawQuery,
-	})
-	r, err := http.NewRequest(method, u.String(), body)
+// newRequest returns a new Request given a method, path, rawQuery, and (optional) body.
+func (c *Client) newRequestWithURL(ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
+	r, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, err
 	}
@@ -116,4 +112,13 @@ func (c *Client) newRequest(method, path, rawQuery string, body io.Reader) (*htt
 	}
 
 	return r, nil
+}
+
+// newRequest returns a new Request given a method, relative path, rawQuery, and (optional) body.
+func (c *Client) newRequest(ctx context.Context, method, path, rawQuery string, body io.Reader) (*http.Request, error) {
+	u := c.BaseURL.ResolveReference(&url.URL{
+		Path:     path,
+		RawQuery: rawQuery,
+	})
+	return c.newRequestWithURL(ctx, method, u.String(), body)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -98,7 +98,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	return c, nil
 }
 
-// newRequest returns a new Request given a method, path, rawQuery, and (optional) body.
+// newRequestWithURL returns a new Request given a method, url, and (optional) body.
 func (c *Client) newRequestWithURL(ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
 	r, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6,6 +6,7 @@
 package client
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -130,7 +131,7 @@ func TestNewRequest(t *testing.T) {
 				t.Fatalf("failed to create client: %v", err)
 			}
 
-			r, err := c.newRequest(tt.method, tt.path, tt.rawQuery, strings.NewReader(tt.body))
+			r, err := c.newRequest(context.Background(), tt.method, tt.path, tt.rawQuery, strings.NewReader(tt.body))
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("got err %v, wantErr %v", err, tt.wantErr)
 			}

--- a/client/pull.go
+++ b/client/pull.go
@@ -102,42 +102,14 @@ type Downloader struct {
 	BufferSize int64
 }
 
-func isSameDomain(urlBase, urlRedirect *url.URL) bool {
-	// Ignore port (":xxx") from host name
-	t1 := strings.SplitN(urlBase.Host, ":", 2)
-	baseHostName := t1[0]
-
-	t2 := strings.SplitN(urlRedirect.Host, ":", 2)
-	redirectHostName := t2[0]
-
-	if baseHostName == redirectHostName {
-		return true
-	}
-
-	if len(redirectHostName) < len(baseHostName) {
-		return false
-	}
-
-	return redirectHostName[len(redirectHostName)-len(baseHostName)-1] == '.'
-}
-
 // httpGetRangeRequest performs HTTP GET range request to URL specified by 'u' in range start-end.
-func (c *Client) httpGetRangeRequest(ctx context.Context, u string, start, end int64) (*http.Response, error) {
-	req, err := c.newRequestWithURL(ctx, http.MethodGet, u, nil)
+func (c *Client) httpGetRangeRequest(ctx context.Context, url string, start, end int64) (*http.Response, error) {
+	req, err := c.newRequestWithURL(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Add("Range", fmt.Sprintf("bytes=%d-%d", start, end))
-
-	parsedURL, err := url.Parse(u)
-	if err != nil {
-		return nil, err
-	}
-
-	if c.AuthToken != "" && isSameDomain(c.BaseURL, parsedURL) {
-		req.Header.Add("Authorization", fmt.Sprintf("BEARER %v", c.AuthToken))
-	}
 
 	return c.HTTPClient.Do(req)
 }

--- a/client/pull.go
+++ b/client/pull.go
@@ -278,6 +278,7 @@ func (c *Client) ConcurrentDownloadImage(ctx context.Context, dst *os.File, arch
 	c.Logger.Logf("Pulling from URL: %s", apiPath)
 
 	customHTTPClient := &http.Client{
+		Transport: c.HTTPClient.Transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if req.Response.StatusCode == http.StatusSeeOther {
 				return http.ErrUseLastResponse
@@ -288,6 +289,8 @@ func (c *Client) ConcurrentDownloadImage(ctx context.Context, dst *os.File, arch
 			}
 			return nil
 		},
+		Jar:     c.HTTPClient.Jar,
+		Timeout: c.HTTPClient.Timeout,
 	}
 
 	req, err := c.newRequest(http.MethodGet, apiPath, q.Encode(), nil)

--- a/client/pull.go
+++ b/client/pull.go
@@ -43,12 +43,12 @@ func (c *Client) DownloadImage(ctx context.Context, w io.Writer, arch, path, tag
 
 	c.Logger.Logf("Pulling from URL: %s", apiPath)
 
-	req, err := c.newRequest(http.MethodGet, apiPath, q.Encode(), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, apiPath, q.Encode(), nil)
 	if err != nil {
 		return err
 	}
 
-	res, err := c.HTTPClient.Do(req.WithContext(ctx))
+	res, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -122,15 +122,15 @@ func isSameDomain(urlBase, urlRedirect *url.URL) bool {
 }
 
 // httpGetRangeRequest performs HTTP GET range request to URL specified by 'u' in range start-end.
-func (c *Client) httpGetRangeRequest(ctx context.Context, endpoint string, start, end int64) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+func (c *Client) httpGetRangeRequest(ctx context.Context, u string, start, end int64) (*http.Response, error) {
+	req, err := c.newRequestWithURL(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Add("Range", fmt.Sprintf("bytes=%d-%d", start, end))
 
-	parsedURL, err := url.Parse(endpoint)
+	parsedURL, err := url.Parse(u)
 	if err != nil {
 		return nil, err
 	}
@@ -293,12 +293,12 @@ func (c *Client) ConcurrentDownloadImage(ctx context.Context, dst *os.File, arch
 		Timeout: c.HTTPClient.Timeout,
 	}
 
-	req, err := c.newRequest(http.MethodGet, apiPath, q.Encode(), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, apiPath, q.Encode(), nil)
 	if err != nil {
 		return err
 	}
 
-	res, err := customHTTPClient.Do(req.WithContext(ctx))
+	res, err := customHTTPClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/client/pull_test.go
+++ b/client/pull_test.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"testing"
 )
@@ -130,35 +129,6 @@ func Test_DownloadImage(t *testing.T) {
 				if !bytes.Equal(fileContent, testContent) {
 					t.Errorf("File contains '%v' - expected '%v'", fileContent, testContent)
 				}
-			}
-		})
-	}
-}
-
-func TestIsSameDomain(t *testing.T) {
-	tests := []struct {
-		name        string
-		baseURL     string
-		redirectURL string
-		same        bool
-	}{
-		{"Equal", "https://library.domain.com", "https://library.domain.com", true},
-		{"SameSubdomain", "https://cloud.domain.com", "https://library.cloud.domain.com", true},
-		{"EqualWithDifferentPorts", "https://library.domain.com:1234", "https://library.domain.com:5678", true},
-		{"EqualOneWithPort", "https://library.domain.com", "https://library.domain.com:1234", true},
-		{"EqualOtherWithPort", "https://library.domain.com:1234", "https://library.domain.com", true},
-		{"NotEqual", "https://library.othersite.com", "https://library.domain.com", false},
-		{"NotEqualReversed", "https://library.domain.com", "https://library.othersite.com", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			u1, _ := url.Parse(tt.baseURL)
-			u2, _ := url.Parse(tt.redirectURL)
-
-			result := isSameDomain(u1, u2)
-			if result != tt.same {
-				t.Fatalf("Mismatch %v is not same/subdomain of %v", u2.String(), u1.String())
 			}
 		})
 	}

--- a/client/push.go
+++ b/client/push.go
@@ -268,10 +268,10 @@ func (c *Client) postFile(ctx context.Context, fileSize int64, imageID string, c
 	c.Logger.Logf("postFile calling %s", postURL)
 
 	// Make an upload request
-	req, _ := c.newRequest(http.MethodPost, postURL, "", callback.GetReader())
+	req, _ := c.newRequest(ctx, http.MethodPost, postURL, "", callback.GetReader())
 	// Content length is required by the API
 	req.ContentLength = fileSize
-	res, err := c.HTTPClient.Do(req.WithContext(ctx))
+	res, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error uploading file to server: %s", err.Error())
 	}

--- a/client/restclient.go
+++ b/client/restclient.go
@@ -70,12 +70,12 @@ func (c *Client) commonRequestHandler(ctx context.Context, method string, path s
 		return []byte{}, fmt.Errorf("error parsing url:\n\t%v", err)
 	}
 
-	req, err := c.newRequest(method, u.Path, u.RawQuery, payload)
+	req, err := c.newRequest(ctx, method, u.Path, u.RawQuery, payload)
 	if err != nil {
 		return []byte{}, fmt.Errorf("error creating %s request:\n\t%v", method, err)
 	}
 
-	res, err := c.HTTPClient.Do(req.WithContext(ctx))
+	res, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return []byte{}, fmt.Errorf("error making request to server:\n\t%v", err)
 	}

--- a/client/version.go
+++ b/client/version.go
@@ -29,12 +29,12 @@ type VersionInfo struct {
 // GetVersion gets version information from the Cloud-Library Service. The context controls the lifetime of
 // the request.
 func (c *Client) GetVersion(ctx context.Context) (vi VersionInfo, err error) {
-	req, err := c.newRequest(http.MethodGet, "version", "", nil)
+	req, err := c.newRequest(ctx, http.MethodGet, "version", "", nil)
 	if err != nil {
 		return VersionInfo{}, err
 	}
 
-	res, err := c.HTTPClient.Do(req.WithContext(ctx))
+	res, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return VersionInfo{}, err
 	}


### PR DESCRIPTION
Also sets `Authorization` header, required for accessing private Sylabs Cloud projects.

Closes #142 , closes #126