### PR TITLE
Support for pulling SIF images directly from OCI registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:18-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.48
+      - image: golangci/golangci-lint:v1.50
   golang-previous:
     docker:
       - image: golang:1.18

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
-    - deadcode
     - decorder
     - depguard
     - dogsled
@@ -28,11 +27,8 @@ linters:
     - nakedret
     - prealloc
     - revive
-    - rowserrcheck
     - staticcheck
-    - structcheck
     - stylecheck
     - tenv
     - typecheck
     - unused
-    - varcheck

--- a/client/client.go
+++ b/client/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -104,9 +104,13 @@ func (c *Client) newRequestWithURL(ctx context.Context, method, url string, body
 	if err != nil {
 		return nil, err
 	}
+
 	if v := c.AuthToken; v != "" {
-		r.Header.Set("Authorization", fmt.Sprintf("BEARER %s", v))
+		if err := (bearerTokenCredentials{authToken: v}).ModifyRequest(r); err != nil {
+			return nil, err
+		}
 	}
+
 	if v := c.UserAgent; v != "" {
 		r.Header.Set("User-Agent", v)
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -161,7 +161,7 @@ func TestNewRequest(t *testing.T) {
 					if got, want := len(authBearer), 1; got != want {
 						t.Fatalf("got %v auth bearer(s), want %v", got, want)
 					}
-					if got, want := authBearer[0], tt.wantAuthBearer; got != want {
+					if got, want := authBearer[0], tt.wantAuthBearer; !strings.EqualFold(got, want) {
 						t.Errorf("got auth bearer %v, want %v", got, want)
 					}
 				}

--- a/client/downloader.go
+++ b/client/downloader.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// filePartDescriptor defines one part of multipart download.
+type filePartDescriptor struct {
+	start int64
+	end   int64
+	cur   int64
+
+	w io.WriterAt
+}
+
+// Write writes buffer 'p' at offset 'start' using 'WriteAt()' to atomically seek and write.
+// Returns bytes written
+func (ps *filePartDescriptor) Write(p []byte) (n int, err error) {
+	n, err = ps.w.WriteAt(p, ps.start+ps.cur)
+	ps.cur += int64(n)
+
+	return
+}
+
+// minInt64 returns minimum value of two arguments
+func minInt64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// Download performs download of contents at url by writing 'size' bytes to 'dst' using credentials 'c'.
+func (c *Client) multipartDownload(ctx context.Context, u string, creds credentials, w io.WriterAt, size int64, spec *Downloader, pb ProgressBar) error {
+	if size <= 0 {
+		return fmt.Errorf("invalid image size (%v)", size)
+	}
+
+	// Initialize the progress bar using passed size
+	pb.Init(size)
+
+	// Clean up (remove) progress bar after download
+	defer pb.Wait()
+
+	// Calculate # of parts
+	parts := uint(1 + (size-1)/spec.PartSize)
+
+	c.Logger.Logf("size: %d, parts: %d, streams: %d, partsize: %d", size, parts, spec.Concurrency, spec.PartSize)
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	// Allocate channel for file part requests
+	ch := make(chan filePartDescriptor, parts)
+
+	// Create download part workers
+	for n := uint(0); n < spec.Concurrency; n++ {
+		g.Go(c.ociDownloadWorker(ctx, u, creds, ch, pb))
+	}
+
+	// Add part download requests
+	for n := uint(0); n < parts; n++ {
+		partSize := minInt64(spec.PartSize, size-int64(n)*spec.PartSize)
+
+		ch <- filePartDescriptor{start: int64(n) * spec.PartSize, end: int64(n)*spec.PartSize + partSize - 1, w: w}
+	}
+
+	// Close worker queue after submitting all requests
+	close(ch)
+
+	// Wait for workers to complete
+	return g.Wait()
+}
+
+func (c *Client) ociDownloadWorker(ctx context.Context, u string, creds credentials, ch chan filePartDescriptor, pb ProgressBar) func() error {
+	return func() error {
+		// Iterate on channel 'ch' to handle download part requests
+		for ps := range ch {
+			written, err := c.ociDownloadBlobPart(ctx, creds, u, &ps)
+			if err != nil {
+				// Cleanly abort progress bar on error
+				pb.Abort(true)
+
+				return err
+			}
+
+			// Increase progress bar by number of bytes downloaded/written
+			pb.IncrBy(int(written))
+		}
+		return nil
+	}
+}
+
+func (c *Client) ociDownloadBlobPart(ctx context.Context, creds credentials, u string, ps *filePartDescriptor) (int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return 0, err
+	}
+	if err := creds.ModifyRequest(req); err != nil {
+		return 0, err
+	}
+
+	req.Header.Add("Range", fmt.Sprintf("bytes=%d-%d", ps.start, ps.end))
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer res.Body.Close()
+
+	return io.Copy(ps, res.Body)
+}
+
+// parseContentRange parses "Content-Range" header (eg. "Content-Range: bytes 0-1000/2000") and returns size
+func parseContentRange(val string) (int64, error) {
+	e := strings.Split(val, " ")
+
+	if !strings.EqualFold(e[0], "bytes") {
+		return 0, errors.New("unexpected/malformed value")
+	}
+
+	rangeElems := strings.Split(e[1], "/")
+
+	if len(rangeElems) != 2 {
+		return 0, errors.New("unexpected/malformed value")
+	}
+
+	return strconv.ParseInt(rangeElems[1], 10, 0)
+}

--- a/client/downloader_test.go
+++ b/client/downloader_test.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type inMemoryBuffer struct {
+	m   sync.Mutex
+	buf []byte
+}
+
+func (f *inMemoryBuffer) WriteAt(p []byte, ofs int64) (n int, err error) {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	n = copy(f.buf[ofs:], p)
+	return
+}
+
+func (f *inMemoryBuffer) Bytes() []byte {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	return f.buf
+}
+
+type stdLogger struct{}
+
+func (l *stdLogger) Log(v ...interface{}) {
+	log.Print(v...)
+}
+
+func (l *stdLogger) Logf(f string, v ...interface{}) {
+	log.Printf(f, v...)
+}
+
+func parseRangeHeader(t *testing.T, val string) (int64, int64) {
+	if val == "" {
+		return 0, 0
+	}
+
+	var start, end int64
+
+	e := strings.SplitN(val, "=", 2)
+
+	byteRange := strings.Split(e[1], "-")
+
+	start, _ = strconv.ParseInt(byteRange[0], 10, 0)
+	end, _ = strconv.ParseInt(byteRange[1], 10, 0)
+
+	return start, end
+}
+
+const (
+	basicAuthUsername = "user"
+	basicAuthPassword = "password"
+)
+
+var (
+	testLogger = &stdLogger{}
+	creds      = &basicCredentials{username: basicAuthUsername, password: basicAuthPassword}
+)
+
+func TestMultistreamDownloader(t *testing.T) {
+	const src = "123456789012345678901234567890"
+	size := int64(len(src))
+
+	defaultSpec := &Downloader{Concurrency: 10, PartSize: 3}
+
+	tests := []struct {
+		name      string
+		size      int64
+		spec      *Downloader
+		expectErr bool
+	}{
+		{"Basic", size, defaultSpec, false},
+		{"WithoutSize", 0, defaultSpec, true},
+		{"SingleStream", size, &Downloader{Concurrency: 1, PartSize: 1}, false},
+		{"SingleStreamWithoutSize", 0, &Downloader{Concurrency: 1, PartSize: 1}, true},
+		{"ManyStreams", size, &Downloader{Concurrency: uint(size), PartSize: 1}, false},
+		{"ManyStreamsWithoutSize", 0, &Downloader{Concurrency: uint(size), PartSize: 1}, true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create test http server for serving "file"
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				start, end := parseRangeHeader(t, r.Header.Get("Range"))
+
+				if username, password, ok := r.BasicAuth(); ok {
+					if got, want := username, basicAuthUsername; got != want {
+						t.Fatalf("unexpected basic auth username: got %v, want %v", got, want)
+					}
+					if got, want := password, basicAuthPassword; got != want {
+						t.Fatalf("unexpected basic auth password: got %v, want %v", got, want)
+					}
+				}
+
+				w.Header().Set("Content-Range", fmt.Sprintf("bytes %v-%v/%v", start, end+1, size))
+				w.Header().Set("Content-Length", fmt.Sprintf("%v", end-start+1))
+
+				w.WriteHeader(http.StatusPartialContent)
+
+				if _, err := io.Copy(w, bytes.NewReader([]byte(src[start:end+1]))); err != nil {
+					t.Fatalf("unexpected error writing http response: %v", err)
+				}
+			}))
+			defer srv.Close()
+
+			c, err := NewClient(&Config{Logger: testLogger})
+			if err != nil {
+				t.Fatalf("error initializing client: %v", err)
+			}
+
+			// Preallocate sink for downloaded file
+			dst := &inMemoryBuffer{buf: make([]byte, size)}
+
+			// Start download
+			err = c.multipartDownload(context.Background(), srv.URL, creds, dst, tt.size, tt.spec, &NoopProgressBar{})
+			if tt.expectErr && err == nil {
+				t.Fatal("unexpected success")
+			}
+			if !tt.expectErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err != nil {
+				return
+			}
+
+			// Compare results with expectations
+			if got, want := string(dst.Bytes()), src; got != want {
+				t.Fatalf("unexpected data: got %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/client/oci.go
+++ b/client/oci.go
@@ -1,0 +1,636 @@
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/opencontainers/go-digest"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// ociRegistryAuth uses Cloud Library endpoint to determine if artifact can be pulled
+// directly from OCI registry.
+//
+// Returns url and credentials (if applicable) for that url.
+func (c *Client) ociRegistryAuth(ctx context.Context, name, tag, arch string, accessTypes []accessType) (*url.URL, *bearerTokenCredentials, error) {
+	// Build raw query string to get token for specified namespace and access
+	v := url.Values{}
+	elems := strings.Split(name, "/")
+	v.Set("namespace", fmt.Sprintf("%v/%v", elems[0], elems[1]))
+
+	ats := make([]string, 0, len(accessTypes))
+	for _, at := range accessTypes {
+		ats = append(ats, string(at))
+	}
+
+	v.Set("accessTypes", strings.Join(ats, ","))
+
+	req, err := c.newRequest(ctx, http.MethodGet, "v1/oci-redirect", v.Encode(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error determining direct OCI registry access: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("error determining direct OCI registry access: %w", err)
+	}
+
+	type ociDownloadRedirectResponse struct {
+		Token       string `json:"token"`
+		RegistryURI string `json:"url"`
+	}
+
+	var ociArtifactSpec ociDownloadRedirectResponse
+
+	if err := json.NewDecoder(res.Body).Decode(&ociArtifactSpec); err != nil {
+		return nil, nil, fmt.Errorf("error decoding direct OCI registry access response: %w", err)
+	}
+
+	endpoint, err := url.Parse(ociArtifactSpec.RegistryURI)
+	if err != nil {
+		return nil, nil, fmt.Errorf("malformed OCI registry URI %v: %v", ociArtifactSpec.RegistryURI, err)
+	}
+	return endpoint, &bearerTokenCredentials{authToken: ociArtifactSpec.Token}, nil
+}
+
+const (
+	mediaTypeSIFConfig = "application/vnd.sylabs.sif.config.v1+json"
+)
+
+type imageConfig struct {
+	Architecture string        `json:"architecture"`
+	OS           string        `json:"os"`
+	RootFS       digest.Digest `json:"rootfs"`
+	Description  string        `json:"description,omitempty"`
+	Signed       bool          `json:"signed"`
+	Encrypted    bool          `json:"encrypted"`
+}
+
+type credentials interface {
+	ModifyRequest(r *http.Request, opts ...modifyRequestOption) error
+}
+
+type basicCredentials struct {
+	username string
+	password string
+}
+
+func (c basicCredentials) ModifyRequest(r *http.Request, opts ...modifyRequestOption) error {
+	r.SetBasicAuth(c.username, c.password)
+	return nil
+}
+
+type bearerTokenCredentials struct {
+	authToken string
+}
+
+func (c bearerTokenCredentials) ModifyRequest(r *http.Request, opts ...modifyRequestOption) error {
+	r.Header.Set("Authorization", fmt.Sprintf("Bearer %v", c.authToken))
+	return nil
+}
+
+type accessType string
+
+const accessTypePull accessType = "pull"
+
+type accessOptions struct {
+	namespace   string
+	accessTypes []accessType
+}
+
+type ociRegistry struct {
+	baseURL    *url.URL
+	httpClient *http.Client
+	userAgent  string
+}
+
+var errArchNotSpecified = errors.New("architecture not specified")
+
+func (r *ociRegistry) getManifestFromIndex(idx v1.Index, arch string) (digest.Digest, error) {
+	// If arch not supplied, return single manifest or error.
+	if arch == "" {
+		if len(idx.Manifests) != 1 || idx.Manifests[0].MediaType != v1.MediaTypeImageManifest {
+			return "", errArchNotSpecified
+		}
+
+		return idx.Manifests[0].Digest, nil
+	}
+
+	// Otherwise, go fish for matching architecture/OS.
+	for _, m := range idx.Manifests {
+		// Only consider image manifests.
+		if m.MediaType != v1.MediaTypeImageManifest {
+			continue
+		}
+
+		// If arch matches, execute!
+		if m.Platform.Architecture == arch {
+			return m.Digest, nil
+		}
+	}
+
+	// If we make it here, no matching OS/architecture was found.
+	return "", fmt.Errorf("no matching OS/architecture (%v) found", arch)
+}
+
+func (r *ociRegistry) getImageManifest(ctx context.Context, c credentials, name, tag, arch string) (digest.Digest, v1.Manifest, error) {
+	if _, idx, err := r.DownloadV1Index(ctx, c, name, tag); err == nil {
+		// Get manifest from index
+		d, err := r.getManifestFromIndex(idx, arch)
+		if err != nil {
+			return "", v1.Manifest{}, err
+		}
+
+		tag = d.String()
+	}
+
+	return r.downloadV1Manifest(ctx, c, name, tag)
+}
+
+func (r *ociRegistry) getImageDetails(ctx context.Context, c credentials, name, tag, arch string) (v1.Descriptor, error) {
+	_, m, err := r.getImageManifest(ctx, c, name, tag, arch)
+	if err != nil {
+		return v1.Descriptor{}, err
+	}
+
+	if got, want := m.Config.MediaType, mediaTypeSIFConfig; got != want {
+		return v1.Descriptor{}, fmt.Errorf("unexpected media type error (got %v, want %v)", got, want)
+	}
+
+	// There should always be exactly one layer (the image blob).
+	if n := len(m.Layers); n != 1 {
+		return v1.Descriptor{}, fmt.Errorf("unexpected # of layers: %v", n)
+	}
+
+	// If architecture was supplied, ensure the image config matches.
+	ic, err := r.getImageConfig(ctx, c, name, m.Config.Digest)
+	if err != nil {
+		return v1.Descriptor{}, err
+	}
+
+	// Ensure architecture matches, if supplied.
+	if got, want := ic.Architecture, arch; want != "" && got != want {
+		return v1.Descriptor{}, &unexpectedArchitectureError{got, want}
+	}
+
+	return m.Layers[0], nil
+}
+
+func (r *ociRegistry) DownloadV1Index(ctx context.Context, c credentials, name, tag string) (digest.Digest, v1.Index, error) {
+	var idx v1.Index
+	d, err := r.downloadManifest(ctx, c, name, tag, &idx, v1.MediaTypeImageIndex)
+	return d, idx, err
+}
+
+func (r *ociRegistry) downloadV1Manifest(ctx context.Context, c credentials, name, tag string) (digest.Digest, v1.Manifest, error) {
+	var m v1.Manifest
+	d, err := r.downloadManifest(ctx, c, name, tag, &m, v1.MediaTypeImageManifest)
+	return d, m, err
+}
+
+func (r *ociRegistry) newRequest(ctx context.Context, method string, u *url.URL, body io.Reader) (*http.Request, error) {
+	return http.NewRequestWithContext(ctx, method, r.baseURL.ResolveReference(u).String(), body)
+}
+
+type modifyRequestOptions struct {
+	httpClient         *http.Client
+	userAgent          string
+	authenticateHeader authHeader // Parsed "Www-Authenticate" header
+	accessOptions      *accessOptions
+}
+
+type modifyRequestOption func(*modifyRequestOptions) error
+
+// withAuthenticateHeader specifies s as the value of the "Www-Authenticate" header.
+func withAuthenticateHeader(s string) modifyRequestOption {
+	return func(opts *modifyRequestOptions) error {
+		ah, err := parseAuthHeader(s)
+		if err != nil {
+			return err
+		}
+		opts.authenticateHeader = ah
+
+		return nil
+	}
+}
+
+type authType int
+
+const (
+	authTypeUnknown authType = iota
+	authTypeBasic
+	authTypeBearer
+)
+
+// parseList parses a comma-separated list of values as described by RFC 2068 and returns list
+// elements.
+//
+// Lifted from https://code.google.com/p/gorilla/source/browse/http/parser/parser.go
+func parseList(value string) []string {
+	var list []string
+	var escape, quote bool
+	b := bytes.Buffer{}
+
+	for _, r := range value {
+		switch {
+		case escape:
+			b.WriteRune(r)
+			escape = false
+		case quote:
+			if r == '\\' {
+				escape = true
+			} else {
+				if r == '"' {
+					quote = false
+				}
+				b.WriteRune(r)
+			}
+		case r == ',':
+			list = append(list, strings.TrimSpace(b.String()))
+			b.Reset()
+		case r == '"':
+			quote = true
+			b.WriteRune(r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+
+	// Append last part.
+	if s := b.String(); s != "" {
+		list = append(list, strings.TrimSpace(s))
+	}
+
+	return list
+}
+
+// parsePairs extracts key/value pairs from a comma-separated list of values as described by RFC
+// 2068 and returns a map[key]value. The resulting values are unquoted. If a list element doesn't
+// contain a "=", the key is the element itself and the value is an empty string.
+//
+// Lifted from https://code.google.com/p/gorilla/source/browse/http/parser/parser.go
+func parsePairs(value string) map[string]string {
+	m := make(map[string]string)
+
+	for _, pair := range parseList(strings.TrimSpace(value)) {
+		if i := strings.Index(pair, "="); i < 0 {
+			m[pair] = ""
+		} else {
+			v := pair[i+1:]
+			if v[0] == '"' && v[len(v)-1] == '"' {
+				// Unquote it.
+				v = v[1 : len(v)-1]
+			}
+			m[pair[:i]] = v
+		}
+	}
+
+	return m
+}
+
+var errInvalidAuthHeader = errors.New("invalid auth header")
+
+type authHeader struct {
+	at      authType
+	realm   string
+	service string
+	scope   string
+}
+
+type unknownAuthTypeError struct {
+	authType string
+}
+
+func (e *unknownAuthTypeError) Error() string {
+	if e.authType != "" {
+		return fmt.Sprintf("unknown auth type '%v'", e.authType)
+	}
+	return "unknown auth type"
+}
+
+func (e *unknownAuthTypeError) Is(target error) bool {
+	var t *unknownAuthTypeError
+	if errors.As(target, &t) {
+		return t.authType == "" || e.authType == t.authType
+	}
+	return false
+}
+
+func getAuthType(raw string) (authType, error) {
+	switch {
+	case strings.EqualFold(raw, "basic"):
+		return authTypeBasic, nil
+	case strings.EqualFold(raw, "bearer"):
+		return authTypeBearer, nil
+	default:
+		return authTypeUnknown, &unknownAuthTypeError{raw}
+	}
+}
+
+func parseAuthHeader(authenticateHeader string) (authHeader, error) {
+	parts := strings.SplitN(authenticateHeader, " ", 2)
+
+	if len(parts) != 2 {
+		return authHeader{}, fmt.Errorf("%w: %v", errInvalidAuthHeader, authenticateHeader)
+	}
+
+	authType, err := getAuthType(parts[0])
+	if err != nil {
+		return authHeader{}, err
+	}
+
+	ah := authHeader{at: authType}
+	pairs := parsePairs(parts[1])
+
+	if v, ok := pairs["realm"]; ok {
+		ah.realm = v
+	}
+	if v, ok := pairs["service"]; ok {
+		ah.service = v
+	}
+	if v, ok := pairs["scope"]; ok {
+		ah.scope = v
+	}
+
+	return ah, nil
+}
+
+type noneCreds struct{}
+
+func (c *noneCreds) ModifyRequest(r *http.Request, opts ...modifyRequestOption) error {
+	r.Header.Set("Authorization", "none")
+
+	return nil
+}
+
+// none returns Credentials that set the authorization header to "none".
+func none() *noneCreds {
+	return &noneCreds{}
+}
+
+func withUserAgent(s string) modifyRequestOption {
+	return func(o *modifyRequestOptions) error {
+		o.userAgent = s
+		return nil
+	}
+}
+
+func withHTTPClient(client *http.Client) modifyRequestOption {
+	return func(o *modifyRequestOptions) error {
+		o.httpClient = client
+		return nil
+	}
+}
+
+var errResetHTTPBody = errors.New("unable to reset HTTP request body")
+
+func (r *ociRegistry) doRequestWithCredentials(req *http.Request, c credentials, opts ...modifyRequestOption) (*http.Response, error) {
+	opts = append(opts,
+		withUserAgent(r.userAgent),
+		withHTTPClient(r.httpClient),
+	)
+
+	// Modify request to include credentials.
+	if err := c.ModifyRequest(req, opts...); err != nil {
+		return nil, err
+	}
+
+	res, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if code := res.StatusCode; code/100 != 2 {
+		defer res.Body.Close()
+
+		return nil, fmt.Errorf("unexpected HTTP status %v", res.StatusCode)
+	}
+
+	return res, nil
+}
+
+func (r *ociRegistry) retryRequestWithCredentials(req *http.Request, c credentials, opts ...modifyRequestOption) (*http.Response, error) {
+	// If the original request contained a body, we need to reset it.
+	if req.Body != nil {
+		if req.GetBody == nil {
+			return nil, errResetHTTPBody
+		}
+
+		rc, err := req.GetBody()
+		if err != nil {
+			return nil, err
+		}
+		req.Body = rc
+	}
+
+	return r.doRequestWithCredentials(req, c, opts...)
+}
+
+func (r *ociRegistry) doRequest(req *http.Request, c credentials, opts ...modifyRequestOption) (*http.Response, error) {
+	res, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if code := res.StatusCode; code/100 != 2 {
+		defer res.Body.Close()
+
+		// If authorization required, re-attempt request using credentials (if supplied) according
+		// to the contents of the "WWW-Authenticate" header (if present).
+		if code == http.StatusUnauthorized {
+			if c == nil {
+				// Unauthenticated requests to certain Harbor APIs require an Authorization header,
+				// even if it's set to "none". 🤦
+				c = none()
+			}
+
+			opts = append(opts, withAuthenticateHeader(res.Header.Get("WWW-Authenticate")))
+			return r.retryRequestWithCredentials(req, c, opts...)
+		}
+
+		return nil, fmt.Errorf("unexpected http status %v", code)
+	}
+
+	return res, nil
+}
+
+// withNamespaceAccess specifies that credentials must be procured that are sufficient to grant the
+// access specified by accessTypes to namespace name.
+func withNamespaceAccess(name string, accessTypes ...accessType) modifyRequestOption {
+	return func(opts *modifyRequestOptions) error {
+		opts.accessOptions = &accessOptions{
+			namespace:   name,
+			accessTypes: accessTypes,
+		}
+
+		return nil
+	}
+}
+
+type unexpectedContentTypeError struct {
+	got  string
+	want string
+}
+
+func (e *unexpectedContentTypeError) Error() string {
+	return fmt.Sprintf("unexpected content type: got %v, want %v", e.got, e.want)
+}
+
+// downloadManifest downloads the manifest of type contentType associated with name/ref in the
+// registry, and unmarshals it to v.
+func (r *ociRegistry) downloadManifest(ctx context.Context, c credentials, name, tag string, v interface{}, contentType string) (digest.Digest, error) {
+	req, err := r.newRequest(ctx, http.MethodGet, &url.URL{Path: fmt.Sprintf("v2/%v/manifests/%v", name, tag)}, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", contentType)
+
+	res, err := r.doRequest(req, c, withNamespaceAccess(name, accessTypePull))
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+
+	// Although we've set the "Accept" header, some registries will return other content types.
+	if got, want := res.Header.Get("Content-Type"), contentType; got != want {
+		return "", &unexpectedContentTypeError{got, want}
+	}
+
+	d := digest.Digest(res.Header.Get("Docker-Content-Digest"))
+
+	if err := d.Validate(); err != nil {
+		return "", err
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
+		return "", err
+	}
+	return d, nil
+}
+
+func (r *ociRegistry) downloadBlob(ctx context.Context, c credentials, name string, d digest.Digest, rangeValue string, w io.Writer) (int64, error) {
+	if err := d.Validate(); err != nil {
+		return 0, err
+	}
+
+	req, err := r.newRequest(ctx, http.MethodGet, &url.URL{Path: fmt.Sprintf("v2/%v/blobs/%v", name, d)}, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	// Set HTTP Range header, if applicable.
+	if rangeValue != "" {
+		req.Header.Set("Range", rangeValue)
+	}
+
+	res, err := r.doRequest(req, c, withNamespaceAccess(name, accessTypePull))
+	if err != nil {
+		return 0, err
+	}
+	defer res.Body.Close()
+
+	// Download blob.
+	return io.Copy(w, res.Body)
+}
+
+var errArchitectureNotPresent = errors.New("architecture not present")
+
+// validateImageConfig validates ic, and returns an error when ic is invalid.
+func validateImageConfig(ic imageConfig) error {
+	if ic.Architecture == "" {
+		return errArchitectureNotPresent
+	}
+
+	return ic.RootFS.Validate()
+}
+
+type unexpectedArchitectureError struct {
+	got  string
+	want string
+}
+
+func (e *unexpectedArchitectureError) Error() string {
+	return fmt.Sprintf("unexpected image architecture: got %v, want %v", e.got, e.want)
+}
+
+func (e *unexpectedArchitectureError) Is(target error) bool {
+	t := &unexpectedArchitectureError{}
+	if !errors.As(target, &t) {
+		return false
+	}
+	return (e.got == t.got || t.got == "") &&
+		(e.want == t.want || t.want == "")
+}
+
+var errDigestNotVerified = errors.New("digest not verified")
+
+func (r *ociRegistry) getImageConfig(ctx context.Context, c credentials, name string, d digest.Digest) (imageConfig, error) {
+	var b bytes.Buffer
+	if _, err := r.downloadBlob(ctx, c, name, d, "", &b); err != nil {
+		return imageConfig{}, err
+	}
+
+	if digest.FromBytes(b.Bytes()) != d {
+		return imageConfig{}, errDigestNotVerified
+	}
+
+	var ic imageConfig
+	if err := json.Unmarshal(b.Bytes(), &ic); err != nil {
+		return imageConfig{}, err
+	}
+
+	if err := validateImageConfig(ic); err != nil {
+		return imageConfig{}, fmt.Errorf("invalid image config: %w", err)
+	}
+
+	return ic, nil
+}
+
+var errOCIDownloadNotSupported = errors.New("not supported")
+
+func (c *Client) ociDownloadImage(ctx context.Context, arch, name, tag string, w io.WriterAt, spec *Downloader, pb ProgressBar) error {
+	// Attempt to obtain (direct) OCI registry auth token
+	registryURI, creds, err := c.ociRegistryAuth(ctx, name, tag, arch, []accessType{accessTypePull})
+	if err != nil {
+		return errOCIDownloadNotSupported
+	}
+
+	// Download directly from OCI registry
+	c.Logger.Logf("Using OCI registry endpoint %v", registryURI)
+
+	reg := &ociRegistry{
+		baseURL:    registryURI,
+		httpClient: c.HTTPClient,
+	}
+
+	// Fetch image manifest to get image details
+	id, err := reg.getImageDetails(ctx, creds, name, tag, arch)
+	if err != nil {
+		return fmt.Errorf("error getting image details: %w", err)
+	}
+
+	imageURI := registryURI.ResolveReference(&url.URL{Path: fmt.Sprintf("v2/%v/blobs/%v", name, id.Digest)}).String()
+
+	return c.multipartDownload(ctx, imageURI, creds, w, id.Size, spec, pb)
+}

--- a/client/oci_test.go
+++ b/client/oci_test.go
@@ -1,0 +1,77 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestOciRegistryAuth(t *testing.T) {
+	const ociRegistryURI = "https://registry"
+
+	tests := []struct {
+		name                       string
+		directOciDownloadSupported bool
+	}{
+		{"Basic", true},
+		{"NotSupported", false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			testShimSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !tt.directOciDownloadSupported {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+
+				response := struct {
+					Token       string `json:"token"`
+					RegistryURI string `json:"url"`
+				}{
+					Token:       "xxx",
+					RegistryURI: ociRegistryURI,
+				}
+
+				if v := r.URL.Query().Get("namespace"); v == "" {
+					t.Fatal("Query string \"namespace\" not set")
+				}
+
+				if v := r.URL.Query().Get("accessTypes"); v == "" {
+					t.Fatalf("Query string \"accessTypes\" not set")
+				}
+
+				if err := json.NewEncoder(w).Encode(&response); err != nil {
+					t.Fatalf("error JSON encoding: %v", err)
+				}
+			}))
+			defer testShimSrv.Close()
+
+			c, err := NewClient(&Config{BaseURL: testShimSrv.URL, Logger: &stdLogger{}, UserAgent: "scs-library-client-unit-tests/1.0"})
+			if err != nil {
+				t.Fatalf("error initializing client: %v", err)
+			}
+
+			u, creds, err := c.ociRegistryAuth(context.Background(), "testproject/testrepo", "latest", "amd64", []accessType{accessTypePull})
+			if tt.directOciDownloadSupported && err != nil {
+				t.Fatalf("error getting OCI registry credentials: %v", err)
+			} else if !tt.directOciDownloadSupported && err == nil {
+				t.Fatal("unexpected success")
+			}
+
+			if tt.directOciDownloadSupported {
+				if got, want := u.String(), ociRegistryURI; got != want {
+					t.Fatalf("unexpected OCI registry URI: got %v, want %v", got, want)
+				}
+
+				if creds == nil {
+					t.Fatal("expecting bearer token credential")
+				}
+			}
+		})
+	}
+}

--- a/client/pull_test.go
+++ b/client/pull_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -9,12 +9,21 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
+	"reflect"
+	"strings"
 	"testing"
+
+	crypto_rand "crypto/rand"
+
+	math_rand "math/rand"
 )
 
 type mockRawService struct {
@@ -129,6 +138,197 @@ func Test_DownloadImage(t *testing.T) {
 				if !bytes.Equal(fileContent, testContent) {
 					t.Errorf("File contains '%v' - expected '%v'", fileContent, testContent)
 				}
+			}
+		})
+	}
+}
+
+func TestParseContentRange(t *testing.T) {
+	const hdr = "bytes 0-1000/1000"
+
+	size, err := parseContentRange(hdr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, want := size, int64(1000); got != want {
+		t.Fatalf("unexpected content length: got %v, want %v", got, want)
+	}
+}
+
+func TestParseContentLengthHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		headerValue    string
+		expectedResult int64
+		expectError    bool
+	}{
+		{"ValidValue", "1234", 1234, false},
+		{"InvalidValue", "xxxx", 0, true},
+		{"EmptyValue", "", -1, false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseContentLengthHeader(tt.headerValue)
+			if !tt.expectError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.expectError && err == nil {
+				t.Fatal("unexpected success")
+			}
+
+			if got, want := result, tt.expectedResult; err == nil && got != want {
+				t.Fatalf("unexpected result: got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func generateSampleData(t *testing.T) []byte {
+	t.Helper()
+
+	const maxSampleDataSize = 1 * 1024 * 1024 // 1 MiB
+
+	size := math_rand.Int63() % maxSampleDataSize
+
+	sampleBytes := make([]byte, size)
+
+	if _, err := crypto_rand.Read(sampleBytes); err != nil {
+		t.Fatalf("error generating random bytes: %v", err)
+	}
+
+	return sampleBytes
+}
+
+func seedRandomNumberGenerator(t *testing.T) {
+	t.Helper()
+
+	var b [8]byte
+	if _, err := crypto_rand.Read(b[:]); err != nil {
+		t.Fatalf("error seeding random number generator: %v", err)
+	}
+	math_rand.Seed(int64(binary.LittleEndian.Uint64(b[:])))
+}
+
+// mockLibraryServer returns *httptest.Server that mocks Cloud Library server; in particular,
+// it has handlers for /version, /v1/images, /v1/imagefile, and /v1/imagepart
+func mockLibraryServer(t *testing.T, sampleBytes []byte, size int64, multistream bool) *httptest.Server {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/version") {
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+
+			if _, err := w.Write([]byte("{\"data\": {\"apiVersion\": \"1.0.0\"}}")); err != nil {
+				t.Fatalf("error writing /version response: %v", err)
+			}
+			return
+		}
+
+		if multistream && strings.HasPrefix(r.URL.Path, "/v1/images/") {
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+
+			if _, err := w.Write([]byte(fmt.Sprintf("{\"data\": {\"size\": %v}}", size))); err != nil {
+				t.Fatalf("error writing /v1/images response: %v", err)
+			}
+
+			return
+		}
+
+		if multistream && strings.HasPrefix(r.URL.Path, "/v1/imagefile/") {
+			redirectURL := &url.URL{
+				Scheme: "http",
+				Host:   r.Host,
+				Path:   "/v1/imagepart/" + strings.TrimPrefix(r.URL.Path, "/v1/imagefile/"),
+			}
+			w.Header().Set("Location", redirectURL.String())
+			w.WriteHeader(http.StatusSeeOther)
+			return
+		}
+
+		// Handle /v1/imagefile (single stream) or /v1/imagepart (multistream)
+
+		// Handle Range request for multipart downloads
+		var start, end int64
+		if val := r.Header.Get("Range"); val != "" {
+			start, end = parseRangeHeader(t, val)
+		} else {
+			start, end = 0, int64(size)-1
+		}
+
+		// Set up response headers
+		w.Header().Set("Content-Length", fmt.Sprintf("%v", end-start+1))
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+
+		// Write image data
+		if _, err := w.Write(sampleBytes[start : end+1]); err != nil {
+			t.Fatalf("error writing response: %v", err)
+		}
+	}))
+	return srv
+}
+
+// TestLegacyDownloadImage downloads random image data from mock library and compares hash to
+// ensure download integrity.
+func TestLegacyDownloadImage(t *testing.T) {
+	tests := []struct {
+		name                string
+		multistreamDownload bool
+	}{
+		{"SingleStream", false},
+		{"MultiStream", true},
+	}
+
+	// Total overkill seeding the random number generator
+	seedRandomNumberGenerator(t)
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			// Generate random bytes to simulate file; upto 256k
+			sampleBytes := generateSampleData(t)
+			size := int64(len(sampleBytes))
+
+			testLogger.Logf("Generated %v bytes of mock image data", size)
+
+			hash := sha256.Sum256(sampleBytes)
+
+			// Create mock library server that responds to '/version' and '/v1/imagefile' only
+			srv := mockLibraryServer(t, sampleBytes, size, tt.multistreamDownload)
+			defer srv.Close()
+
+			// Initialize scs-library-client
+			c, err := NewClient(&Config{BaseURL: srv.URL, Logger: testLogger})
+			if err != nil {
+				t.Fatalf("error initializing client: %v", err)
+			}
+
+			// Initialize sink for downloaded sample image
+			dst := &inMemoryBuffer{buf: make([]byte, size)}
+
+			err = c.legacyDownloadImage(
+				context.Background(),
+				"amd64",
+				"entity/collection/container",
+				"tag",
+				dst,
+				&Downloader{Concurrency: 4, PartSize: 64 * 1024},
+				&NoopProgressBar{},
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Compare sha256 hash of data sent with hash of data received
+			if got, want := sha256.Sum256(dst.Bytes()), hash; !reflect.DeepEqual(got, want) {
+				t.Fatalf("unexpected hash: got %x, want %v", got, want)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module github.com/sylabs/scs-library-client
 
-go 1.17
+go 1.18
 
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/go-log/log v0.2.0
+	github.com/opencontainers/go-digest v1.0.0
+	github.com/opencontainers/image-spec v1.0.2
 	github.com/sylabs/json-resp v0.8.2
-	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29
+	golang.org/x/sync v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,11 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/go-log/log v0.2.0 h1:z8i91GBudxD5L3RmF0KVpetCbcGWAV7q1Tw1eRwQM9Q=
 github.com/go-log/log v0.2.0/go.mod h1:xzCnwajcues/6w7lne3yK2QU7DBPW7kqbgPGG5AF65U=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
+github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/sylabs/json-resp v0.8.2 h1:k2dgtMXL+nztYtxrI24Zck/sfexyly4D1+X504eZTKQ=
 github.com/sylabs/json-resp v0.8.2/go.mod h1:Q9X4wRlZNPv3x76KaL8vTCBO4aC/DP2gh13xdtEqd1g=
-golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 h1:w8s32wxx3sY+OjLlv9qltkLU5yvJzxjjgiHWLjdIcw4=
-golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
Implements support for pulling SIF images directly from OCI registry without using Cloud Library as an intermediary.