### PR TITLE
Remove obsolete DownloadImage() function

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7,8 +7,13 @@ package client
 
 import (
 	"context"
+	crypto_rand "crypto/rand"
+	"encoding/binary"
 	"io"
+	"log"
+	math_rand "math/rand"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 )
@@ -181,4 +186,19 @@ func TestNewRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func seedRandomNumberGenerator() {
+	var b [8]byte
+	if _, err := crypto_rand.Read(b[:]); err != nil {
+		log.Fatalf("error seeding random number generator: %v", err)
+	}
+	math_rand.Seed(int64(binary.LittleEndian.Uint64(b[:])))
+}
+
+func TestMain(m *testing.M) {
+	// Total overkill seeding the random number generator
+	seedRandomNumberGenerator()
+
+	os.Exit(m.Run())
 }

--- a/client/downloader.go
+++ b/client/downloader.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/client/downloader.go
+++ b/client/downloader.go
@@ -67,7 +67,7 @@ func (c *Client) multipartDownload(ctx context.Context, u string, creds credenti
 
 	// Create download part workers
 	for n := uint(0); n < spec.Concurrency; n++ {
-		g.Go(c.ociDownloadWorker(ctx, u, creds, ch, pb))
+		g.Go(c.downloadWorker(ctx, u, creds, ch, pb))
 	}
 
 	// Add part download requests
@@ -84,11 +84,11 @@ func (c *Client) multipartDownload(ctx context.Context, u string, creds credenti
 	return g.Wait()
 }
 
-func (c *Client) ociDownloadWorker(ctx context.Context, u string, creds credentials, ch chan filePartDescriptor, pb ProgressBar) func() error {
+func (c *Client) downloadWorker(ctx context.Context, u string, creds credentials, ch chan filePartDescriptor, pb ProgressBar) func() error {
 	return func() error {
 		// Iterate on channel 'ch' to handle download part requests
 		for ps := range ch {
-			written, err := c.ociDownloadBlobPart(ctx, creds, u, &ps)
+			written, err := c.downloadBlobPart(ctx, creds, u, &ps)
 			if err != nil {
 				// Cleanly abort progress bar on error
 				pb.Abort(true)
@@ -103,7 +103,7 @@ func (c *Client) ociDownloadWorker(ctx context.Context, u string, creds credenti
 	}
 }
 
-func (c *Client) ociDownloadBlobPart(ctx context.Context, creds credentials, u string, ps *filePartDescriptor) (int64, error) {
+func (c *Client) downloadBlobPart(ctx context.Context, creds credentials, u string, ps *filePartDescriptor) (int64, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return 0, err

--- a/client/downloader_test.go
+++ b/client/downloader_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -17,6 +17,16 @@ import (
 	"strings"
 	"sync"
 	"testing"
+)
+
+const (
+	basicAuthUsername = "user"
+	basicAuthPassword = "password"
+)
+
+var (
+	testLogger = &stdLogger{}
+	creds      = &basicCredentials{username: basicAuthUsername, password: basicAuthPassword}
 )
 
 type inMemoryBuffer struct {
@@ -49,6 +59,19 @@ func (l *stdLogger) Logf(f string, v ...interface{}) {
 	log.Printf(f, v...)
 }
 
+func TestParseContentRange(t *testing.T) {
+	const hdr = "bytes 0-1000/1000"
+
+	size, err := parseContentRange(hdr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, want := size, int64(1000); got != want {
+		t.Fatalf("unexpected content length: got %v, want %v", got, want)
+	}
+}
+
 func parseRangeHeader(t *testing.T, val string) (int64, int64) {
 	if val == "" {
 		return 0, 0
@@ -65,16 +88,6 @@ func parseRangeHeader(t *testing.T, val string) (int64, int64) {
 
 	return start, end
 }
-
-const (
-	basicAuthUsername = "user"
-	basicAuthPassword = "password"
-)
-
-var (
-	testLogger = &stdLogger{}
-	creds      = &basicCredentials{username: basicAuthUsername, password: basicAuthPassword}
-)
 
 func TestMultistreamDownloader(t *testing.T) {
 	const src = "123456789012345678901234567890"

--- a/client/pull.go
+++ b/client/pull.go
@@ -70,7 +70,7 @@ type ProgressBar interface {
 	Wait()
 }
 
-// ConcurrentDownloadImage implements a multi-part (concurrent) downloader for
+// DownloadImage implements a multi-part (concurrent) downloader for
 // Cloud Library images. spec is used to define transfer parameters. pb is an
 // optional progress bar interface.  If pb is nil, NoopProgressBar is used.
 //
@@ -78,7 +78,7 @@ type ProgressBar interface {
 // only files larger than Downloader.PartSize. It will automatically adjust the
 // concurrency for source files that do not meet minimum size for multi-part
 // downloads.
-func (c *Client) ConcurrentDownloadImage(ctx context.Context, dst *os.File, arch, path, tag string, spec *Downloader, pb ProgressBar) error {
+func (c *Client) DownloadImage(ctx context.Context, dst *os.File, arch, path, tag string, spec *Downloader, pb ProgressBar) error {
 	if pb == nil {
 		pb = &NoopProgressBar{}
 	}

--- a/client/pull_test.go
+++ b/client/pull_test.go
@@ -8,7 +8,6 @@ package client
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/binary"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -84,16 +83,6 @@ func generateSampleData(t *testing.T) []byte {
 	return sampleBytes
 }
 
-func seedRandomNumberGenerator(t *testing.T) {
-	t.Helper()
-
-	var b [8]byte
-	if _, err := crypto_rand.Read(b[:]); err != nil {
-		t.Fatalf("error seeding random number generator: %v", err)
-	}
-	math_rand.Seed(int64(binary.LittleEndian.Uint64(b[:])))
-}
-
 // mockLibraryServer returns *httptest.Server that mocks Cloud Library server; in particular,
 // it has handlers for /version, /v1/images, /v1/imagefile, and /v1/imagepart
 func mockLibraryServer(t *testing.T, sampleBytes []byte, size int64, multistream bool) *httptest.Server {
@@ -163,9 +152,6 @@ func TestLegacyDownloadImage(t *testing.T) {
 		{"SingleStream", false},
 		{"MultiStream", true},
 	}
-
-	// Total overkill seeding the random number generator
-	seedRandomNumberGenerator(t)
 
 	for _, tt := range tests {
 		tt := tt

--- a/client/pull_test.go
+++ b/client/pull_test.go
@@ -21,19 +21,6 @@ import (
 	math_rand "math/rand"
 )
 
-func TestParseContentRange(t *testing.T) {
-	const hdr = "bytes 0-1000/1000"
-
-	size, err := parseContentRange(hdr)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if got, want := size, int64(1000); got != want {
-		t.Fatalf("unexpected content length: got %v, want %v", got, want)
-	}
-}
-
 func TestParseContentLengthHeader(t *testing.T) {
 	t.Parallel()
 

--- a/client/pull_test.go
+++ b/client/pull_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -6,17 +6,13 @@
 package client
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -25,123 +21,6 @@ import (
 
 	math_rand "math/rand"
 )
-
-type mockRawService struct {
-	t           *testing.T
-	code        int
-	testFile    string
-	reqCallback func(*http.Request, *testing.T)
-	httpAddr    string
-	httpPath    string
-	httpServer  *httptest.Server
-	baseURI     string
-}
-
-func (m *mockRawService) Run() {
-	mux := http.NewServeMux()
-	mux.HandleFunc(m.httpPath, m.ServeHTTP)
-	m.httpServer = httptest.NewServer(mux)
-	m.httpAddr = m.httpServer.Listener.Addr().String()
-	m.baseURI = "http://" + m.httpAddr
-}
-
-func (m *mockRawService) Stop() {
-	m.httpServer.Close()
-}
-
-func (m *mockRawService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if m.reqCallback != nil {
-		m.reqCallback(r, m.t)
-	}
-	w.WriteHeader(m.code)
-	inFile, err := os.Open(m.testFile)
-	if err != nil {
-		m.t.Errorf("error opening file %v:", err)
-	}
-	defer inFile.Close()
-
-	_, err = io.Copy(w, bufio.NewReader(inFile))
-	if err != nil {
-		m.t.Errorf("Test HTTP server unable to output file: %v", err)
-	}
-}
-
-func Test_DownloadImage(t *testing.T) {
-	f, err := os.CreateTemp("", "test")
-	if err != nil {
-		t.Fatalf("Error creating a temporary file for testing")
-	}
-	tempFile := f.Name()
-	f.Close()
-	os.Remove(tempFile)
-
-	tests := []struct {
-		name         string
-		arch         string
-		path         string
-		tag          string
-		outFile      string
-		code         int
-		testFile     string
-		tokenFile    string
-		checkContent bool
-		expectError  bool
-	}{
-		{"Bad library ref", "amd64", "entity/collection/im,age", "tag", tempFile, http.StatusBadRequest, "test_data/test_sha256", "test_data/test_token", false, true},
-		{"Server error", "amd64", "entity/collection/image", "tag", tempFile, http.StatusInternalServerError, "test_data/test_sha256", "test_data/test_token", false, true},
-		{"Tags in path", "amd64", "entity/collection/image:tag", "anothertag", tempFile, http.StatusOK, "test_data/test_sha256", "test_data/test_token", false, true},
-		{"Good Download", "amd64", "entity/collection/image", "tag", tempFile, http.StatusOK, "test_data/test_sha256", "test_data/test_token", true, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			m := mockRawService{
-				t:        t,
-				code:     tt.code,
-				testFile: tt.testFile,
-				httpPath: fmt.Sprintf("/v1/imagefile/%s:%s", tt.path, tt.tag),
-			}
-
-			m.Run()
-			defer m.Stop()
-
-			c, err := NewClient(&Config{AuthToken: tt.tokenFile, BaseURL: m.baseURI})
-			if err != nil {
-				t.Errorf("Error initializing client: %v", err)
-			}
-
-			out, err := os.OpenFile(tt.outFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o777)
-			if err != nil {
-				t.Errorf("Error opening file %s for writing: %v", tt.outFile, err)
-			}
-
-			err = c.DownloadImage(context.Background(), out, tt.arch, tt.path, tt.tag, nil)
-
-			out.Close()
-
-			if err != nil && !tt.expectError {
-				t.Errorf("Unexpected error: %v", err)
-			}
-			if err == nil && tt.expectError {
-				t.Errorf("Unexpected success. Expected error.")
-			}
-
-			if tt.checkContent {
-				fileContent, err := os.ReadFile(tt.outFile)
-				if err != nil {
-					t.Errorf("Error reading test output file: %v", err)
-				}
-				testContent, err := os.ReadFile(tt.testFile)
-				if err != nil {
-					t.Errorf("Error reading test file: %v", err)
-				}
-				if !bytes.Equal(fileContent, testContent) {
-					t.Errorf("File contains '%v' - expected '%v'", fileContent, testContent)
-				}
-			}
-		})
-	}
-}
 
 func TestParseContentRange(t *testing.T) {
 	const hdr = "bytes 0-1000/1000"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sylabs/scs-library-client
+module github.com/sylabs/scs-library-client/v2
 
 go 1.18
 


### PR DESCRIPTION
Removes obsolete (Client).DownloadImage() function
- rename `ConcurrentDownloadImage()` to `DownloadImage()`
- rename unexported function `ociDownloadBlobPart` `downloadBlobPart()`
- unit test improvements
