### PR TITLE
Improved OCI redirect handling

### DIFF
--- a/client/oci.go
+++ b/client/oci.go
@@ -40,6 +40,10 @@ func (c *Client) ociRegistryAuth(ctx context.Context, name string, accessTypes [
 	v := url.Values{}
 	v.Set("namespace", name)
 
+	// Setting 'mapped' to '1' (true) enables support for mapping short library refs to
+	// fully-qualified name
+	v.Set("mapped", strconv.Itoa(1))
+
 	ats := make([]string, 0, len(accessTypes))
 	for _, at := range accessTypes {
 		ats = append(ats, string(at))

--- a/client/oci.go
+++ b/client/oci.go
@@ -634,6 +634,7 @@ func (r *ociRegistry) getImageConfig(ctx context.Context, creds credentials, nam
 
 var errOCIDownloadNotSupported = errors.New("not supported")
 
+// newOCIRegistry returns *ociRegistry, credentials for that registry, and the (optionally) remapped image name
 func (c *Client) newOCIRegistry(ctx context.Context, name string, accessTypes []accessType) (*ociRegistry, *bearerTokenCredentials, string, error) {
 	// Attempt to obtain (direct) OCI registry auth token
 	originalName := name

--- a/client/pull_test.go
+++ b/client/pull_test.go
@@ -212,7 +212,7 @@ func seedRandomNumberGenerator(t *testing.T) {
 	if _, err := crypto_rand.Read(b[:]); err != nil {
 		t.Fatalf("error seeding random number generator: %v", err)
 	}
-	math_rand.Seed(int64(binary.LittleEndian.Uint64(b[:])))
+	math_rand.New(math_rand.NewSource(int64(binary.LittleEndian.Uint64(b[:]))))
 }
 
 // mockLibraryServer returns *httptest.Server that mocks Cloud Library server; in particular,


### PR DESCRIPTION
Add 'mapping=1' to /v1/oci-redirect query string to allow client-side selection of mapping semantics